### PR TITLE
Make `encode_*` methods return size. Add support for encoding/decoding arrays.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "endian_codec"
 description = "Decode / Encode rust types as packed bytes with specific bytes order"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sylwester Rąpała <sylwesterrapala@outlook.com>"]
 edition = "2018"
 
@@ -13,7 +13,7 @@ license = "Apache-2.0 OR MIT"
 readme = "README.md"
 
 [dependencies]
-endian_codec_derive = { version = "0.1", optional = true }
+endian_codec_derive = { version = "0.1.2", optional = true }
 
 [features]
 default = ["derive"]

--- a/endian_codec_derive/Cargo.toml
+++ b/endian_codec_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endian_codec_derive"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sylwester Rąpała <sylwesterrapala@outlook.com>"]
 edition = "2018"
 

--- a/endian_codec_derive/src/lib.rs
+++ b/endian_codec_derive/src/lib.rs
@@ -162,24 +162,27 @@ fn derive_endian_impl(
             Endian::Little => quote! {
                 impl #impl_generics EncodeLE for #name #ty_generics #where_clause {
                      #[inline]
-                     fn encode_as_le_bytes(&self, bytes: &mut [u8]) {
+                     fn encode_as_le_bytes(&self, bytes: &mut [u8]) -> usize {
                        #body
+                       Self::PACKED_LEN
                      }
                 }
             },
             Endian::Big => quote! {
                 impl #impl_generics EncodeBE for #name #ty_generics #where_clause {
                      #[inline]
-                     fn encode_as_be_bytes(&self, bytes: &mut [u8]) {
+                     fn encode_as_be_bytes(&self, bytes: &mut [u8]) -> usize {
                        #body
+                       Self::PACKED_LEN
                      }
                 }
             },
             Endian::Mixed => quote! {
                 impl #impl_generics EncodeME for #name #ty_generics #where_clause {
                      #[inline]
-                     fn encode_as_me_bytes(&self, bytes: &mut [u8]) {
+                     fn encode_as_me_bytes(&self, bytes: &mut [u8]) -> usize {
                        #body
+                       Self::PACKED_LEN
                      }
                 }
             },


### PR DESCRIPTION
* Make `encode_*` methods return packed size.
* Add support for encoding/decoding arrays of elements that implement `{En,De}code{L,B,M}E`.
* Bump package version.